### PR TITLE
Adding relativePath field to parent section

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -49,9 +49,10 @@ type MavenProject struct {
 
 // Represent the parent of the project
 type Parent struct {
-	GroupId    string `xml:"groupId"`
-	ArtifactId string `xml:"artifactId"`
-	Version    string `xml:"version"`
+	GroupId      string `xml:"groupId"`
+	ArtifactId   string `xml:"artifactId"`
+	Version      string `xml:"version"`
+	RelativePath string `xml:"relativePath"`
 }
 
 // Represent a dependency of the project


### PR DESCRIPTION
I would appreciate it if you could add the support for the `relativePath` option in the `parent` section.
More information can be found [here](https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#:~:text=we%20would%20have%20to%20add%20the%20%3CrelativePath%3E%20element%20to%20our%20parent%20section).
Thanks!